### PR TITLE
Charset meta UTF-8 definition needed to show non-Latin characters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>    
+<html>
     <head>
+        <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="style.css">
         <title>The Matrix</title>
     </head>


### PR DESCRIPTION
For some reason the Sanskrit characters are not rendered correctly on my local machine. Adding a `<meta charset="UTF-8">` in the head fixes that.